### PR TITLE
hashtag comment support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn process_file(file: &Path, map: &mut HashMap<String, LocData>, ignore: &Vec<St
     for line in file_content.lines() {
         if line.is_empty() {
             obj.blank += 1;
-        } else if line.trim().starts_with("//") {
+        } else if line.trim().starts_with("//") || line.trim().starts_with("#") {
             obj.comment += 1;
         } else {
             obj.code += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn process_file(file: &Path, map: &mut HashMap<String, LocData>, ignore: &Vec<St
     };
     obj.files += 1;
     for line in file_content.lines() {
-        if line.is_empty() {
+        if line.trim().is_empty() {
             obj.blank += 1;
         } else if line.trim().starts_with("//") || line.trim().starts_with("#") {
             obj.comment += 1;


### PR DESCRIPTION
For some weird reason, some languages use hashtags to mark comments instead of "//". idk why hashtags are used TwT
frik hashtags

but, i added hashtag comment support so that it can count comments in languages like python (AAAAAA, SNAKE TwT) 